### PR TITLE
Leap year

### DIFF
--- a/lib/days.js
+++ b/lib/days.js
@@ -44,7 +44,8 @@ function daysInMonth(month, year) {
  */
 
 function isLeapYear(year) {
-  return ((0 == year % 4) && (0 != year % 100))
+  return (0 == year % 400)
+    || ((0 == year % 4) && (0 != year % 100))
     || (0 == year);
 }
 


### PR DESCRIPTION
Fix leap year calculation:
- take year into account when calculating number of days in a month
- years 2000, 2400 etc. are leap years
