### PR TITLE
Fix short months selection on 31th of the month

### DIFF
--- a/lib/days.js
+++ b/lib/days.js
@@ -79,14 +79,11 @@ function Days() {
   // emit "day"
   this.body.on('click', 'a', function(e){
     var el = o(e.target);
-    var day = parseInt(el.text(), 10);
     var data = el.data('date').split('-');
     var year = data[0];
     var month = data[1];
-    var date = new Date;
-    date.setYear(year);
-    date.setMonth(month);
-    date.setDate(day);
+    var day = data[2];
+    var date = new Date(year, month, day);
     self.select(date);
     self.emit('change', date);
     return false;


### PR DESCRIPTION
Due to javascript date peculiarities calendar did not work properly on
the last day of long months (for example on 5/31)

`onclick` handler looked (more or less) like this

```
date = new Date;
date.setYear(year);
date.setMonth(month);
date.setDay(day);
```

However if current date is 2013-05-31 trying to set month to - for
example - September, would temporarily create an invalid date
(2013-09-31) which `Date` object promptly 'fixes' for us converting it to
2013-10-01

New code sets year, month, and day in the `Date` constructor thus avoiding
the issue.
