### PR TITLE
Switching from component-jquery to components-jquery

### DIFF
--- a/component.json
+++ b/component.json
@@ -10,7 +10,7 @@
   ],
   "dependencies": {
     "component/range": "1.0.0",
-    "component/jquery": "*",
+    "components/jquery": "*",
     "component/emitter": "1.0.0",
     "component/in-groups-of": "1.0.0"
   },

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "ui"
   ],
   "dependencies": {
-    "jquery-component": "*",
+    "components-jquery": "*",
     "emitter-component": "*",
     "in-groups-of": "*"
   },


### PR DESCRIPTION
The [component/jquery](https://github.com/component/jquery) suggests to use the [components/jquery](https://github.com/components/jquery) instead.

There's others opened PR removing jquery dependency, but as none was merged yet, I'll let this here as well.
