### PR TITLE
restore pointer cursor for days

### DIFF
--- a/lib/calendar.css
+++ b/lib/calendar.css
@@ -17,3 +17,7 @@
 .calendar-table td {
   user-select: none;
 }
+
+.calendar-table td a {
+  cursor: pointer;
+}


### PR DESCRIPTION
days `a` nodes don't have `href` attribute, so browsers do not think they are clickable
by forcing cursor to pointer we let user know that clicking on days is possible
